### PR TITLE
 #166995306: Get all Property Adverts  from database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: node_js
 node_js:
   - "stable"
 npm:
-  - "6.9.2
-  "
+  - "6.9.2"
 cache:
   directories:
     - "node_modules"

--- a/server/controller/propertyController.js
+++ b/server/controller/propertyController.js
@@ -118,6 +118,30 @@ class Property {
     }
     return successResponse(res, 200, 'Advert Successfully deleted');
   }
+
+  /**
+*  get all advert
+* @params {object} req
+* @params {object} res
+* @returns {object} all advert
+*/
+
+  static allAdvert(req, res) {
+    const adverts = Properties.getAll();
+    const advertList = adverts.map((advert) => {
+      const advertOwnerID = advert.owner;
+      const users = Users.getAll();
+      const advertOwner = users.find(user => user.id === advertOwnerID);
+
+      advert.ownerEmail = advertOwner.email;
+      advert.ownerPhoneNumber = advertOwner.phone_number;
+      const { owner, ...advertDetails } = advert;
+      return advertDetails;
+    });
+
+    return successResponse(res, 200, advertList);
+  }
 }
+
 
 export default Property;

--- a/server/model/propertyModel.js
+++ b/server/model/propertyModel.js
@@ -46,6 +46,24 @@ class Property {
     return Property.table.find(advert => advert.id === id);
   }
 
+  /**
+   * @param {id} Property id
+   * @param {object} data
+   * @return {object} property
+   */
+  static update(id, data) {
+    const advert = this.getOne(id);
+    const index = Property.table.indexOf(advert);
+    Property.table[index].state = data.state || advert.state;
+    Property.table[index].city = data.city || advert.city;
+    Property.table[index].address = data.address || advert.address;
+    Property.table[index].type = data.type || advert.type;
+    Property.table[index].image_url = data.image_url || advert.image_url;
+    Property.table[index].price = data.price || advert.price;
+    Property.table[index].updated_at = new Date();
+    return Property.table[index];
+  }
+
 
   /**
   * @param {id} Property id

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -15,5 +15,7 @@ router.post('/property', Auth.verifyToken, cloudinaryConfig, multerUploads, prop
 router.patch('/property/:id', Auth.verifyToken, cloudinaryConfig, multerUploads, propertyController.updateAdvert);
 router.patch('/property/:id/sold', Auth.verifyToken, propertyController.markSold);
 router.delete('/property/:id', Auth.verifyToken, propertyController.deleteAdvert);
+router.get('/property/', propertyController.allAdvert);
+
 
 export default router;


### PR DESCRIPTION
 #### What does this PR do?
Users can get all property adverts in the database

#### Description of Task to be completed?
- Add  a get route for fetching all property advert

#### How should this be manually tested?
1. After cloning the repo, cd into it.
2. Checkout to `ft-get-all-advert-endpoint- 166995306`.
3. Run npm install to install dependencies.
4. Run npm start to start the server.
5. Open postman run **GET** on `http://localhost:3000/api/v1/property` to get all property adverts.

#### Any background context you want to provide?
Nil

#### Screenshot
![image](https://user-images.githubusercontent.com/42867330/60453382-e9675900-9c28-11e9-9149-8df02e711986.png)

#### What are the relevant pivotal tracker stories?
 [#166995306](https://www.pivotaltracker.com/story/show/166995306)
