### PR TITLE
#167205944: users(agent) Mark a property as sold Database Endpoint

### DIFF
--- a/server/controller/propertyController.js
+++ b/server/controller/propertyController.js
@@ -79,5 +79,33 @@ class Property {
       return serverError(res);
     }
   }
+
+  /**
+ * mark an advert as sold
+ * @params {object} req
+ * @params {object} res
+ * @returns {object} updated advert object
+ */
+  static async markSold(req, res) {
+    try {
+      const findOneQuery = `SELECT * FROM property WHERE id = $1 AND owner ='${
+        req.user.id
+      }'`;
+      const updateQueryStatus = 'UPDATE property SET status=$1, updated_at=$2 WHERE id=$3 returning *';
+      const { rows } = await db.query(findOneQuery, [req.params.id]);
+      if (!rows[0]) {
+        return clientError(res, 404, ...['status', 'error', 'message', 'You are not authorize to mark this advert as sold']);
+      }
+      const values = [
+        req.body.status = 'Sold',
+        new Date(),
+        req.params.id,
+      ];
+      const updatedSold = await db.query(updateQueryStatus, values);
+      return successResponse(res, 200, updatedSold.rows[0]);
+    } catch (error) {
+      return serverError(res);
+    }
+  }
 }
 export default Property;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -13,7 +13,7 @@ router.post('/auth/create', Validator.validateSignUpDetails, userController.crea
 router.post('/auth/login', Validator.validateLoginDetails, userController.login);
 router.post('/property', Auth.verifyToken, cloudinaryConfig, multerUploads, Validator.validatePropertyPostFields, propertyController.postAdvert);
 router.patch('/property/:id', Auth.verifyToken, cloudinaryConfig, multerUploads, Validator.validateIdParameter, propertyController.updateAdvert);
-// router.patch('/property/:id/sold', Auth.verifyToken, Validator.validateIdParameter, propertyController.markSold);
+router.patch('/property/:id/sold', Auth.verifyToken, Validator.validateIdParameter, propertyController.markSold);
 // router.delete('/property/:id', Auth.verifyToken, Validator.validateIdParameter, propertyController.deleteAdvert);
 // router.get('/property/', propertyController.allAdvert);
 // router.get('/property/:id', Validator.validateIdParameter, propertyController.getAdvert);


### PR DESCRIPTION
 #### What does this PR do?
User(Agent) can mark a property advert as sold

#### Description of Task to be completed?
- Add  patch route for updating property advert status

#### How should this be manually tested?
1. After cloning the repo, cd into it.
2. Checkout to `ft-mark-sold- dbendpoint-167205944`.
3. Run npm install to install dependencies.
4. Run npm start to start the server.
5. Open postman run **PATCH** on `http://localhost:3000/api/v1/property/:id/sold` to mark property as sold.

#### Any background context you want to provide?
Nil

#### Screenshot
![image](https://user-images.githubusercontent.com/42867330/60451675-7e1b8800-9c24-11e9-9f66-1bccc91651ce.png)
![image](https://user-images.githubusercontent.com/42867330/60451681-84a9ff80-9c24-11e9-82b1-c256b95ffbde.png)

#### What are the relevant pivotal tracker stories?
 [#167205944](https://www.pivotaltracker.com/story/show/167205944)