### PR TITLE
 #167206062: user can get all advert and all advert of the s…

### DIFF
--- a/server/controller/propertyController.js
+++ b/server/controller/propertyController.js
@@ -107,5 +107,38 @@ class Property {
       return serverError(res);
     }
   }
+  /**
+*  get all advert
+* @params {object} req
+* @params {object} res
+* @returns {object} all advert
+*/
+
+  static async allAdvert(req, res) {
+    const findAllQuery = 'SELECT  A. *, B.id AS owner, B.email AS ownerEmail, B.phone_number AS ownerPhoneNumber FROM property A INNER JOIN users B on A.owner=B.id';
+    try {
+      const { rows, rowCount } = await db.query(findAllQuery);
+      if (rowCount === 0) {
+        return clientError(res, 404, ...['status', 'error', 'message', 'Advert not found']);
+      }
+      /**
+  *  get all advert of same type
+  * @params {object} req
+  * @params {object} res
+  * @returns {object} all advert of same type
+  */
+      if (req.query.type) {
+        const { type } = req.query;
+        const propertyTypeResult = rows.filter(property => property.type === type);
+        if (propertyTypeResult.length) {
+          return successResponse(res, 200, propertyTypeResult);
+        }
+        return clientError(res, 404, ...['status', 'error', 'error', `${type} property type is not available at the moment`]);
+      }
+      return successResponse(res, 200, rows);
+    } catch (error) {
+      return serverError(res);
+    }
+  }
 }
 export default Property;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -14,8 +14,9 @@ router.post('/auth/login', Validator.validateLoginDetails, userController.login)
 router.post('/property', Auth.verifyToken, cloudinaryConfig, multerUploads, Validator.validatePropertyPostFields, propertyController.postAdvert);
 router.patch('/property/:id', Auth.verifyToken, cloudinaryConfig, multerUploads, Validator.validateIdParameter, propertyController.updateAdvert);
 router.patch('/property/:id/sold', Auth.verifyToken, Validator.validateIdParameter, propertyController.markSold);
-// router.delete('/property/:id', Auth.verifyToken, Validator.validateIdParameter, propertyController.deleteAdvert);
-// router.get('/property/', propertyController.allAdvert);
+router.get('/property/', propertyController.allAdvert);
 // router.get('/property/:id', Validator.validateIdParameter, propertyController.getAdvert);
+// router.delete('/property/:id', Auth.verifyToken, Validator.validateIdParameter, propertyController.deleteAdvert);
+
 
 export default router;


### PR DESCRIPTION
 #### What does this PR do?
Users can get all property adverts in the database

#### Description of Task to be completed?
- Add  a get route for fetching all property advert
-Add param query for fetching all property adverts of the same type

#### How should this be manually tested?
1. After cloning the repo, cd into it.
2. Checkout to `ft-get-all-advert-dbendpoint- 167206062`.
3. Run npm install to install dependencies.
4. Run npm start to start the server.
5. Open postman run **GET** on `http://localhost:3000/api/v1/property` to get all property adverts.

#### Any background context you want to provide?
Nil

#### Screenshot
![image](https://user-images.githubusercontent.com/42867330/60453382-e9675900-9c28-11e9-9149-8df02e711986.png)

#### What are the relevant pivotal tracker stories?
 [ #167206062](https://www.pivotaltracker.com/story/show/ 167206062)
